### PR TITLE
new syslog option

### DIFF
--- a/nxapi/nxapi.json
+++ b/nxapi/nxapi.json
@@ -6,6 +6,10 @@
  "default_ttl" : "7200",
  "max_size" : "1000"
 },
+"syslogd": {
+ "host" : "0.0.0.0",
+ "port" : "51400"
+},
 "global_filters" : {
  "whitelisted" : "false"
 },


### PR DESCRIPTION
Add syslog option for nxtool (works fine with syslog-ng)

example of syslog-ng.conf :
filter f_naxsi { match("NAXSI_FMT" value("MESSAGE")); };
source WWW.MONSITE.FR {
file("/var/log/nginx/logs/WWW.MONSITE.FR-error.log" flags(no-parse));
};
destination nxtool {
        tcp("10.10.10.1" port(51401) template("$MSG\n"));
};
log { source(WWW.MONSITE.FR); filter(f_naxsi); destination(nxtool); };
