### PR TITLE
Add the gopher:// url scheme to RFI list

### DIFF
--- a/naxsi_config/naxsi_core.rules
+++ b/naxsi_config/naxsi_core.rules
@@ -48,6 +48,7 @@ MainRule "str:data://" "msg:data:// scheme" "mz:ARGS|BODY|$HEADERS_VAR:Cookie" "
 MainRule "str:glob://" "msg:glob:// scheme" "mz:ARGS|BODY|$HEADERS_VAR:Cookie" "s:$RFI:8" id:1107;
 MainRule "str:phar://" "msg:phar:// scheme" "mz:ARGS|BODY|$HEADERS_VAR:Cookie" "s:$RFI:8" id:1108;
 MainRule "str:file://" "msg:file:// scheme" "mz:ARGS|BODY|$HEADERS_VAR:Cookie" "s:$RFI:8" id:1109;
+MainRule "str:gopher://" "msg:file:// scheme" "mz:ARGS|BODY|$HEADERS_VAR:Cookie" "s:$RFI:8" id:1110;
 
 #######################################
 ## Directory traversal IDs:1200-1299 ##


### PR DESCRIPTION
In php, curl will happily use the `gopher://` protocol, so it might be cool to blacklist it ;)