### PR TITLE
nxtool.py always uses same index

### DIFF
--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -453,7 +453,7 @@ class ESInject(NxInjector):
             print "Unexpected error:", sys.exc_info()[0]
             print "Unable to json.dumps : "
             pprint.pprint(items)
-        bulk(self.es, items, index="nxapi", doc_type="events", raise_on_error=True)
+        bulk(self.es, items, index=self.cfg["elastic"]["index"], doc_type="events", raise_on_error=True)
         self.total_commits += count
         logging.debug("Written "+str(self.total_commits)+" events")
         print "Written "+str(self.total_commits)+" events"

--- a/nxapi/nxapi/nxtypificator.py
+++ b/nxapi/nxapi/nxtypificator.py
@@ -44,7 +44,7 @@ class Typificator(object):
                 body = {'query': {}}
                 for k,v in self.cfg['global_filters'].iteritems():
                     body['query'].update({'match':{k:v}})
-                data = self.es_instance.search(index='nxapi', doc_type='events',
+                data = self.es_instance.search(index=self.cfg["elastic"]["index"], doc_type='events',
                                                size=size, from_=position,
                                                body=body)
                 data = data['hits']['hits']  # we don't care about metadata


### PR DESCRIPTION
If you've got another index name in your nxapi.json whitelists were not generated successfully until you use the indexname "nxapi". Now it works with every other index declared in the config.