### PR TITLE
fix potential vulnerability in the content-disposition parsing

### DIFF
--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -1664,8 +1664,9 @@ ngx_http_dummy_multipart_parse(ngx_http_request_ctx_t *ctx,
     ** Content-Disposition: form-data; name="lastname"\r\n\r\n
     ** <DATA>
     */
+    /* 31 = echo -n "content-disposition: form-data;" | wc -c */
     if (ngx_strncasecmp(src+idx, 
-			(u_char *) "content-disposition: form-data;", 30)) {
+			(u_char *) "content-disposition: form-data;", 31)) {
       ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, 
 		    "Unknown content-type: [%s]", src+idx);
       if (ngx_http_apply_rulematch_v_n(&nx_int__uncommon_post_format, ctx, r, NULL, NULL, BODY, 1, 0)) {
@@ -1673,7 +1674,7 @@ ngx_http_dummy_multipart_parse(ngx_http_request_ctx_t *ctx,
       }
       return ;
     }
-    idx += 30;
+    idx += 31;
     line_end = (u_char *) ngx_strchr(src+idx, '\n');
     if (!line_end) {
       if (ngx_http_apply_rulematch_v_n(&nx_int__uncommon_post_format, ctx, r, NULL, NULL, BODY, 1, 0)) {


### PR DESCRIPTION
There is a potential vulnerability in the `ngx_http_dummy_multipart_parse`, more precisely in the content-disposition parsing
`"content-disposition: form-data;"` is  31 characters long but
`ngx_strncasecmp(src + idx, (u_char *) "content-disposition: form-data;", 30)`
only compares the first 30 characters of the content-disposition header string,
so by sending `"content-disposition: form-data "` the request is considered valid, and is not blocked by Naxsi (no 418 status code)

To test that, with telnet:
`$ telnet localhost 80`
paste this:
```
POST / HTTP/1.1
Host: localhost
Content-Length: 146
Expect: 100-continue
Content-Type: multipart/form-data; boundary=------------------------161cbaba5e0b7b9f

```
hit enter, you will receive `HTTP/1.1 100 Continue`
then paste:
<pre>
--------------------------161cbaba5e0b7b9f
<b>Content-Disposition: form-data  name="text"</b>

default
--------------------------161cbaba5e0b7b9f--
</pre>
Hit enter, the request will succeed and you will receive `HTTP/1.1 200 OK` instead of `HTTP/1.1 418`