### PR TITLE
Reduce length of haystack before re-searching for needle

### DIFF
--- a/naxsi_src/naxsi_utils.c
+++ b/naxsi_src/naxsi_utils.c
@@ -75,8 +75,11 @@ strfaststr(unsigned char *haystack, unsigned int hl,
       else {
 	  if (found+nl >= end)
 	    break;
-	  if (found+nl < end)
+	  if (found+nl < end) {
+	    /* the haystack is shrinking */
 	    cpt = found+1;
+	    hl = (unsigned int) (end - cpt);
+	  }
 	}
     }
   return (NULL);


### PR DESCRIPTION
Fix for issue #275 

When *only* the first letter of the needle is found in the haystack but the rest of the string doesn't match, the `strfaststr` function loops back and looks for another occurrence of the first letter of the needle. When it does this, it needs to shrink the haystack to avoid searching beyond the original haystack boundary.