### PR TITLE
Fix for issue #329

### DIFF
--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -418,11 +418,11 @@ class ESInject(NxInjector):
                     "events" : {
                         "_ttl" : { "enabled" : "true", "default" : "4d" },
                         "properties" : { "var_name" : {"type": "string", "index" : "not_analyzed"},
-                                         "uri" : {"type": "string", "index" : "not_analyzed"},
-                                         "zone" : {"type": "string", "index" : "not_analyzed"},
-                                         "server" : {"type": "string", "index" : "not_analyzed"},
-                                         "whitelisted" : {"type" : "string", "index" : "not_analyzed"},
-                                         "ip" : { "type" : "string", "index" : "not_analyzed"}
+                                         "uri" : {"type": "string", "index" : "not_analyzed", "fielddata": true},
+                                         "zone" : {"type": "string", "index" : "not_analyzed", "fielddata": true},
+                                         "server" : {"type": "string", "index" : "not_analyzed", "fielddata": true},
+                                         "whitelisted" : {"type" : "string", "index" : "not_analyzed", "fielddata": true},
+                                         "ip" : { "type" : "string", "index" : "not_analyzed", "fielddata": true}
                                          }
                         }
                     })

--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -369,12 +369,23 @@ class ESInject(NxInjector):
         NxInjector.__init__(self, auto_commit_limit)
         self.es = es
         self.cfg = cfg
+        try:
+            es5_flag = str(os.environ['ES5_ENABLE'])
+            if es5_flag in ['true', 'True', 'TRUE', '1', 'y', 'Y', 'YES', 'Yes', 'yes']:
+                self.es5 = True
+                print 'Elastic Search 5.X (ES5_ENABLE) Flag is Enabled'
+            else:
+                self.es5 = False
+        except KeyError:
+            self.es5 = False
         # self.host = host
         # self.index = index
         # self.collection = collection
         # self.login = login
         # self.password = password
         self.set_mappings()
+
+
     # def esreq(self, pidx_uri, data, method="PUT"):
     #     try:
     #         body = json.dumps(data)
@@ -399,36 +410,70 @@ class ESInject(NxInjector):
     #         return False
     #     return True
     def set_mappings(self):
-        try:
-            self.es.create(
-                index=self.cfg["elastic"]["index"],
-                doc_type=self.cfg["elastic"]["doctype"],
-                #            id=repo_name,
-                body={},
-                ignore=409 # 409 - conflict - would be returned if the document is already there
+        if self.es5 == True:
+            try:
+                self.es.indices.create(
+                    index=self.cfg["elastic"]["index"],
+                    ignore=400 # Ignore 400 cause by IndexAlreadyExistsException when creating an index
                 )
-        except:
-            print "Unable to create the index/collection : "+self.cfg["elastic"]["index"]+" "+self.cfg["elastic"]["doctype"]
-            return
-        try:
-            self.es.indices.put_mapping(
-                index=self.cfg["elastic"]["index"],
-                doc_type=self.cfg["elastic"]["doctype"],
-                body={
-                    "events" : {
-                        "_ttl" : { "enabled" : "true", "default" : "4d" },
-                        "properties" : { "var_name" : {"type": "string", "index" : "not_analyzed"},
-                                         "uri" : {"type": "string", "index" : "not_analyzed", "fielddata": true},
-                                         "zone" : {"type": "string", "index" : "not_analyzed", "fielddata": true},
-                                         "server" : {"type": "string", "index" : "not_analyzed", "fielddata": true},
-                                         "whitelisted" : {"type" : "string", "index" : "not_analyzed", "fielddata": true},
-                                         "ip" : { "type" : "string", "index" : "not_analyzed", "fielddata": true}
-                                         }
+            except Exception as idxadd_error:
+                print "Unable to create the index/collection for ES 5.X: "+self.cfg["elastic"]["index"]+" "+self.cfg["elastic"]["doctype"]+ ", Error: " + str(idxadd_error)
+            try:
+                self.es.indices.put_mapping(
+                    index=self.cfg["elastic"]["index"],
+                    doc_type=self.cfg["elastic"]["doctype"],
+                    body={
+                        "events" : {
+                            # * (Note: The _timestamp and _ttl fields were deprecated and are now removed in ES 5.X.
+                            # deleting documents from an index is very expensive compared to deleting whole indexes.
+                            # That is why time based indexes are recommended over this sort of thing and why
+                            # _ttl was deprecated in the first place)
+                            #"_ttl" : { "enabled" : "true", "default" : "4d" },
+                            "properties" : { "var_name" : {"type": "keyword"},
+                                "uri" : {"type": "keyword"},
+                                "zone" : {"type": "keyword"},
+                                "server" : {"type": "keyword"},
+                                "whitelisted" : {"type" : "keyword"},
+                                "ip" : {"type" : "keyword"}
+                            }
                         }
-                    })
-        except:
-            print "Unable to set mapping on index/collection : "+self.cfg["elastic"]["index"]+" "+self.cfg["elastic"]["doctype"]
-            return
+                })
+            except Exception as mapset_error:
+                print "Unable to set mapping on index/collection for ES 5.X: "+self.cfg["elastic"]["index"]+" "+self.cfg["elastic"]["doctype"]+", Error: "+str(mapset_error)
+                return
+        else:
+            try:
+                self.es.create(
+                    index=self.cfg["elastic"]["index"],
+                    doc_type=self.cfg["elastic"]["doctype"],
+                    #            id=repo_name,
+                    body={},
+                    ignore=409 # 409 - conflict - would be returned if the document is already there
+                )
+            except Exception as idxadd_error:
+                print "Unable to create the index/collection : "+self.cfg["elastic"]["index"]+" "+self.cfg["elastic"]["doctype"]+", Error: "+str(idxadd_error)
+                return
+            try:
+                self.es.indices.put_mapping(
+                    index=self.cfg["elastic"]["index"],
+                    doc_type=self.cfg["elastic"]["doctype"],
+                    body={
+                        "events" : {
+                            "_ttl" : { "enabled" : "true", "default" : "4d" },
+                            "properties" : { "var_name" : {"type": "string", "index":"not_analyzed"},
+                                        "uri" : {"type": "string", "index":"not_analyzed"},
+                                        "zone" : {"type": "string", "index":"not_analyzed"},
+                                        "server" : {"type": "string", "index":"not_analyzed"},
+                                        "whitelisted" : {"type" : "string", "index":"not_analyzed"},
+                                        "ip" : { "type" : "string", "index":"not_analyzed"}
+                            }
+                        }
+                })
+            except Exception as mapset_error:
+                print "Unable to set mapping on index/collection : "+self.cfg["elastic"]["index"]+" "+self.cfg["elastic"]["doctype"]+", Error: "+str(mapset_error)
+                return
+
+
     def commit(self):
         """Process list of dict (yes) and push them to DB """
         self.total_objs += len(self.nlist)
@@ -444,6 +489,8 @@ class ESInject(NxInjector):
                 for x in entry.keys():
                     if isinstance(entry[x], basestring):
                         entry[x] = unicode(entry[x], errors='replace')
+                if self.es5:
+                    entry['_ttl'] = '30s'
                 items.append(entry)
                 count += 1
         mapfunc = partial(json.dumps, ensure_ascii=False)

--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -373,7 +373,7 @@ class ESInject(NxInjector):
             es5_flag = str(os.environ['ES5_ENABLE'])
             if es5_flag in ['true', 'True', 'TRUE', '1', 'y', 'Y', 'YES', 'Yes', 'yes']:
                 self.es5 = True
-                print 'Elastic Search 5.X (ES5_ENABLE) Flag is Enabled'
+                print 'Elastic Search 5.X Flag (ES5_ENABLE) is Enabled'
             else:
                 self.es5 = False
         except KeyError:
@@ -410,7 +410,7 @@ class ESInject(NxInjector):
     #         return False
     #     return True
     def set_mappings(self):
-        if self.es5 == True:
+        if self.es5:
             try:
                 self.es.indices.create(
                     index=self.cfg["elastic"]["index"],
@@ -489,8 +489,6 @@ class ESInject(NxInjector):
                 for x in entry.keys():
                     if isinstance(entry[x], basestring):
                         entry[x] = unicode(entry[x], errors='replace')
-                if self.es5:
-                    entry['_ttl'] = '30s'
                 items.append(entry)
                 count += 1
         mapfunc = partial(json.dumps, ensure_ascii=False)

--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -369,15 +369,7 @@ class ESInject(NxInjector):
         NxInjector.__init__(self, auto_commit_limit)
         self.es = es
         self.cfg = cfg
-        try:
-            es5_flag = str(os.environ['ES5_ENABLE'])
-            if es5_flag in ['true', 'True', 'TRUE', '1', 'y', 'Y', 'YES', 'Yes', 'yes']:
-                self.es5 = True
-                print 'Elastic Search 5.X Flag (ES5_ENABLE) is Enabled'
-            else:
-                self.es5 = False
-        except KeyError:
-            self.es5 = False
+        self.es_version =  cfg["elastic"].get("version", None)
         # self.host = host
         # self.index = index
         # self.collection = collection
@@ -410,7 +402,7 @@ class ESInject(NxInjector):
     #         return False
     #     return True
     def set_mappings(self):
-        if self.es5:
+        if self.es_version == '5':
             try:
                 self.es.indices.create(
                     index=self.cfg["elastic"]["index"],

--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -369,7 +369,7 @@ class ESInject(NxInjector):
         NxInjector.__init__(self, auto_commit_limit)
         self.es = es
         self.cfg = cfg
-        self.es_version =  cfg["elastic"].get("version", None)
+        self.es_version =  cfg["elastic"]["version"]
         # self.host = host
         # self.index = index
         # self.collection = collection

--- a/nxapi/nxtool.py
+++ b/nxapi/nxtool.py
@@ -111,7 +111,7 @@ except ValueError:
     sys.exit(-1)
 
 if cfg.cfg["elastic"].get("version", None) is None:
-    print "Specify version '1' or '2' in [elasticsearch] section."
+    print "Specify version '1' or '2' or '5' in [elasticsearch] section."
     sys.exit(-1)
 
 if options.server is not None:

--- a/nxapi/nxtool.py
+++ b/nxapi/nxtool.py
@@ -110,10 +110,6 @@ try:
 except ValueError:
     sys.exit(-1)
 
-if cfg.cfg["elastic"].get("version", None) is None:
-    print "Specify version '1' or '2' or '5' in [elasticsearch] section."
-    sys.exit(-1)
-
 if options.server is not None:
     cfg.cfg["global_filters"]["server"] = options.server
 
@@ -160,6 +156,14 @@ except KeyError:
     use_ssl = False
     
 es = elasticsearch.Elasticsearch(cfg.cfg["elastic"]["host"], use_ssl=use_ssl)
+# Get ES version from the client and avail it at cfg
+es_version =  es.info()['version'].get('number', None)
+if es_version is not None:
+    cfg.cfg["elastic"]["version"] = es_version.split(".")[0]
+if cfg.cfg["elastic"].get("version", None) is None:
+    print "Failed to get version from ES, Specify version ['1'/'2'/'5'] in [elasticsearch] section"
+    sys.exit(-1)
+
 translate = NxTranslate(es, cfg)
 
 


### PR DESCRIPTION
We need to Enable field data on all the text fields for searching, in ES 5.0 Strings are mapped to text fields where the field data is false by default. 

nxparse.py: fileddata : true is being set at mapping for: whitelisted, server, uri, zone, ip

(*Note: string fields is being depricated by text and keyword at ES 5.0)

[Source](https://www.elastic.co/guide/en/elasticsearch/reference/current/fielddata.html)