### PR TITLE
Update nxparse.py errno 98

### DIFF
--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -67,6 +67,7 @@ class NxReader():
           print "Unable to get syslog host and port"
           sys.exit(1)
         s = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
           s.bind((host,port))
           s.listen(10)


### PR DESCRIPTION
error 98 when tryind to bing TIME_WAIT connection with nxapi --syslog.
This is because the previous execution has left the socket in a TIME_WAIT state, and can’t be immediately reused.

```python
Written 6 events
Bind failed. Error Code : 98 Message Address already in use
Listening for syslog incoming 0.0.0.0 port 5140
Traceback (most recent call last):
  File "/usr/bin/nxtool.py", line 460, in <module>
    reader.read_files()
  File "/usr/lib/python2.7/site-packages/nxapi/nxparse.py", line 94, in read_files
    while self.read_syslog(self.syslog) is True:
  File "/usr/lib/python2.7/site-packages/nxapi/nxparse.py", line 77, in read_syslog
    conn, addr = s.accept()
  File "/usr/lib64/python2.7/socket.py", line 202, in accept
    sock, addr = self._sock.accept()
socket.error: [Errno 22] Invalid argument
```