### PR TITLE
Make default behavior when no MainRule(s) are present more expliciti

### DIFF
--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -108,6 +108,14 @@ ngx_http_rule_t nx_int__empty_post_body = {/*type*/ 0, /*whitelist flag*/ 0,
 ngx_http_rule_t *nx_int__libinject_sql; /*ID:17*/
 ngx_http_rule_t *nx_int__libinject_xss; /*ID:18*/
 
+ngx_http_rule_t nx_int__no_rules = {/*type*/ 0, /*whitelist flag*/ 0, 
+				    /*wl_id ptr*/ NULL, /*rule_id*/ 19,
+				    /*log_msg*/ NULL, /*score*/ 0, 
+				    /*sscores*/ NULL,
+				    /*sc_block*/ 0,  /*sc_allow*/ 0, 
+				    /*block*/ 0,  /*allow*/ 0, /*drop*/ 1, /*log*/ 0,
+				    /*br ptrs*/ NULL};
+
 
 
 
@@ -2105,7 +2113,9 @@ ngx_http_dummy_uri_parse(ngx_http_dummy_main_conf_t *main_cf,
   if ( (ctx->block && !ctx->learning) || ctx->drop )
     return ;
   if (!main_cf->generic_rules && !cf->generic_rules) {
-    dummy_error_fatal(ctx, r, "no generic rules ?!");
+    tmp.data = NULL;
+    tmp.len = 0;
+    ngx_http_apply_rulematch_v_n(&nx_int__no_rules, ctx, r, &tmp, &tmp, URL, 1, 0);
     return ;
   }
   tmp.len = r->uri.len;

--- a/t/31norules.t
+++ b/t/31norules.t
@@ -1,0 +1,73 @@
+#vi:filetype=perl
+
+
+# A AJOUTER :
+# TEST CASE AVEC UNE REGLE SUR UN HEADER GENERIQUE
+# La même sur des arguments :)
+
+use lib 'lib';
+use Test::Nginx::Socket;
+
+repeat_each(3);
+
+plan tests => repeat_each(1) * blocks();
+no_root_location();
+no_long_string();
+$ENV{TEST_NGINX_SERVROOT} = server_root();
+run_tests();
+
+
+__DATA__
+=== TEST 1: Basic GET request with no rules, drop
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- config
+location / {
+	 SecRulesEnabled;
+	 LearningMode;
+	 DeniedUrl "/RequestDenied";
+	 CheckRule "$SQL >= 8" BLOCK;
+	 CheckRule "$RFI >= 8" BLOCK;
+	 CheckRule "$TRAVERSAL >= 4" BLOCK;
+	 CheckRule "$XSS >= 8" BLOCK;
+	 LibInjectionXss;
+	 CheckRule "$LIBINJECTION_XSS >= 8" BLOCK;
+	 LibInjectionSql;
+	 CheckRule "$LIBINJECTION_SQL >= 8" BLOCK;
+
+  	 root $TEST_NGINX_SERVROOT/html/;
+         index index.html index.htm;
+}
+location /RequestDenied {
+	 return 412;
+}
+--- request
+GET /?a=buibui
+--- error_code: 412
+=== TEST 1.1: Basic GET request with no rules, whitelist the special rule.
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- config
+location / {
+	 SecRulesEnabled;
+	 BasicRule wl:19;
+	 LearningMode;
+	 DeniedUrl "/RequestDenied";
+	 CheckRule "$SQL >= 8" BLOCK;
+	 CheckRule "$RFI >= 8" BLOCK;
+	 CheckRule "$TRAVERSAL >= 4" BLOCK;
+	 CheckRule "$XSS >= 8" BLOCK;
+	 LibInjectionXss;
+	 CheckRule "$LIBINJECTION_XSS >= 8" BLOCK;
+	 LibInjectionSql;
+	 CheckRule "$LIBINJECTION_SQL >= 8" BLOCK;
+
+  	 root $TEST_NGINX_SERVROOT/html/;
+         index index.html index.htm;
+}
+location /RequestDenied {
+	 return 412;
+}
+--- request
+GET /?a=buibui
+--- error_code: 200


### PR DESCRIPTION
 - add internal rule with id `19` that is triggered when no MainRules are present
 - this rule can now be white-listed for people that want to rely _only_ on ie. libinjection
