### PR TITLE
fixes #329 and #408; fielddata on id and support for ES6

### DIFF
--- a/nxapi/nxapi/nxparse.py
+++ b/nxapi/nxapi/nxparse.py
@@ -403,7 +403,7 @@ class ESInject(NxInjector):
     #         return False
     #     return True
     def set_mappings(self):
-        if self.es_version == '5':
+        if (self.es_version == '6') or (self.es_version == '5'):
             try:
                 self.es.indices.create(
                     index=self.cfg["elastic"]["index"],
@@ -433,6 +433,7 @@ class ESInject(NxInjector):
                                 "zone" : {"type": "keyword"},
                                 "server" : {"type": "keyword"},
                                 "whitelisted" : {"type" : "keyword"},
+                                "id" : {"type" : "keyword"},
                                 "ip" : {"type" : "keyword"}
                             }
                         }

--- a/nxapi/nxapi/nxtransform.py
+++ b/nxapi/nxapi/nxtransform.py
@@ -541,7 +541,7 @@ class NxTranslate():
             template[field] = x
         if self.cfg["elastic"].get("version", None) == "1":
             esq['facets'] =  { "facet_results" : {"terms": { "field": field, "size" : self.es_max_size} }}
-        elif self.cfg["elastic"].get("version", None) in ["2", "5"]:
+        elif self.cfg["elastic"].get("version", None) in ["2", "5", "6"]:
             esq['aggregations'] =  { "agg1" : {"terms": { "field": field, "size" : self.es_max_size} }}
         else:
             print "Unknown / Unspecified ES version in nxapi.json : {0}".format(self.cfg["elastic"].get("version", "#UNDEFINED"))
@@ -551,7 +551,7 @@ class NxTranslate():
 
         if self.cfg["elastic"].get("version", None) == "1":
             total = res['facets']['facet_results']['total']
-        elif self.cfg["elastic"].get("version", None) in ["2", "5"]:
+        elif self.cfg["elastic"].get("version", None) in ["2", "5", "6"]:
             total = res['hits']['total']
         else:
             print "Unknown / Unspecified ES version in nxapi.json : {0}".format(self.cfg["elastic"].get("version", "#UNDEFINED"))
@@ -565,7 +565,7 @@ class NxTranslate():
                 count += 1
                 if count > limit:
                     break
-        elif self.cfg["elastic"].get("version", None) in ["2", "5"]:
+        elif self.cfg["elastic"].get("version", None) in ["2", "5", "6"]:
             for x in res['aggregations']['agg1']['buckets']:
                 ret.append('{0} {1}% (total: {2}/{3})'.format(x['key'], round((float(x['doc_count']) / total) * 100, 2), x['doc_count'], total))
                 count += 1
@@ -584,7 +584,7 @@ class NxTranslate():
         #
         if self.cfg["elastic"].get("version", None) == "1":
             esq['facets'] =  { "facet_results" : {"terms": { "field": key, "size" : 50000} }}
-        elif self.cfg["elastic"].get("version", None) in ["2", "5"]:
+        elif self.cfg["elastic"].get("version", None) in ["2", "5", "6"]:
             esq['aggregations'] =  { "agg1" : {"terms": { "field": key, "size" : 50000} }}
         else:
             print "Unknown / Unspecified ES version in nxapi.json : {0}".format(self.cfg["elastic"].get("version", "#UNDEFINED"))
@@ -595,7 +595,7 @@ class NxTranslate():
             for x in res['facets']['facet_results']['terms']:
                 if x['term'] not in uniques:
                     uniques.append(x['term'])
-        elif self.cfg["elastic"].get("version", None) in ["2", "5"]:
+        elif self.cfg["elastic"].get("version", None) in ["2", "5", "6"]:
             for x in res['aggregations']['agg1']['buckets']:
                 if x['key'] not in uniques:
                     uniques.append(x['key'])


### PR DESCRIPTION
This brings support for ES6 and fixes the problem with ES5 and ES6 with fielddata on [id]
> elasticsearch.exceptions.RequestError: TransportError(400, u'search_phase_execution_exception', u'Fielddata is disabled on text fields by default. Set fielddata=true on [id] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory. Alternatively use a keyword field instead.')

