### PR TITLE
Remove compilation warnings -Werror=stringop-truncation

### DIFF
--- a/naxsi_src/naxsi_utils.c
+++ b/naxsi_src/naxsi_utils.c
@@ -662,7 +662,7 @@ ngx_http_wlr_finalize_hashtables(ngx_conf_t *cf, ngx_http_dummy_loc_conf_t  *dlc
     {
       size_t fname_size = strlen((char *)dlc->whitelist_file->data);
       if(fname_size <= 1024) {
-        strncpy(fname, (char *)dlc->whitelist_file->data, strlen((char *)dlc->whitelist_file->data));
+        strcpy(fname, (char *)dlc->whitelist_file->data);
       }
     }
   }


### PR DESCRIPTION
Remove compilation warnings -Werror=stringop-truncation with GCC 8