### PR TITLE
Some includes are required for OpenBSD

### DIFF
--- a/naxsi_src/naxsi_net.h
+++ b/naxsi_src/naxsi_net.h
@@ -7,7 +7,7 @@
 #ifndef __NAXSI_NET_H__
 #define __NAXSI_NET_H__
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/types.h>


### PR DESCRIPTION
OpenBSD requires a few includes already defined in a conditional for FreeBSD, this adds OpenBSD as an alternative to FreeBSD in the condition.

Without those includes, there are compilation errors about AF_INET and AF_INET6 being undefined.