### PR TITLE
naxsi_src/naxsi_runtime.c: fix build without x_forwarded_for

### DIFF
--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -2842,10 +2842,12 @@ ngx_http_naxsi_data_parse(ngx_http_request_ctx_t* ctx, ngx_http_request_t* r)
   unsigned int      n = 0;
   ngx_table_elt_t** h = NULL;
   ngx_array_t       a;
+#if (NGX_HTTP_X_FORWARDED_FOR)
   if (r->headers_in.x_forwarded_for.nelts >= 1) {
     a = r->headers_in.x_forwarded_for;
     n = a.nelts;
   }
+#endif
   if (n >= 1)
     h = a.elts;
   if (n >= 1) {
@@ -2879,6 +2881,7 @@ ngx_http_naxsi_update_current_ctx_status(ngx_http_request_ctx_t*    ctx,
 
   /*cr, sc, cf, ctx*/
   if (cf->check_rules && ctx->special_scores) {
+#if (NGX_HTTP_X_FORWARDED_FOR)
     if (r->headers_in.x_forwarded_for.nelts >= 1) {
       a = r->headers_in.x_forwarded_for;
       n = a.nelts;
@@ -2896,7 +2899,9 @@ ngx_http_naxsi_update_current_ctx_status(ngx_http_request_ctx_t*    ctx,
         memcpy(ip.data, h[0]->value.data, ip.len);
         ignore = nx_can_ignore_ip(&ip, cf) || nx_can_ignore_cidr(&ip, cf);
       }
-    } else {
+    } else
+#endif
+    {
       ngx_str_t* ip = &r->connection->addr_text;
       NX_DEBUG(_debug_whitelist_ignore,
                NGX_LOG_DEBUG_HTTP,


### PR DESCRIPTION
`x_forwarded_for` is not available if realip, geo, geoip or proxy modules aren't enabled resulting in the following build failure since version 1.1a and https://github.com/nbs-system/naxsi/commit/07a056ccd36bc3c5c40dc17991db226cb8cf6241:

```
/home/buildroot/autobuild/instance-3/output-1/build/nginx-naxsi-1.3/naxsi_src/naxsi_runtime.c: In function 'ngx_http_naxsi_data_parse':
/home/buildroot/autobuild/instance-3/output-1/build/nginx-naxsi-1.3/naxsi_src/naxsi_runtime.c:2846:20: error: 'ngx_http_headers_in_t' has no member named 'x_forwarded_for'
   if (r->headers_in.x_forwarded_for.nelts >= 1) {
                    ^
```

Fixes:
 - http://autobuild.buildroot.org/results/cdbc1536f6b5de3d4c836efa2f0dcaf0cdbb1462

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>