### PR TITLE
PCRE2 compatibility

### DIFF
--- a/naxsi_src/naxsi.h
+++ b/naxsi_src/naxsi.h
@@ -19,7 +19,6 @@
 #include <ngx_http.h>
 #include <ngx_http_core_module.h>
 #include <ngx_md5.h>
-#include <pcre.h>
 
 extern ngx_module_t ngx_http_naxsi_module;
 

--- a/naxsi_src/naxsi_config.c
+++ b/naxsi_src/naxsi_config.c
@@ -322,8 +322,11 @@ naxsi_zone(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
 
         custom_rule->target_rx = ngx_pcalloc(r->pool, sizeof(ngx_regex_compile_t));
         return_value_if(!custom_rule->target_rx, NGX_CONF_ERROR);
-
+#if (NGX_PCRE2)
+        custom_rule->target_rx->options  = PCRE2_CASELESS | PCRE2_MULTILINE;
+#else
         custom_rule->target_rx->options  = PCRE_CASELESS | PCRE_MULTILINE;
+#endif
         custom_rule->target_rx->pattern  = custom_rule->target;
         custom_rule->target_rx->pool     = r->pool;
         custom_rule->target_rx->err.len  = 0;
@@ -442,7 +445,11 @@ naxsi_rx(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
   ha.len  = tmp->len - strlen(RX_T);
   rgc     = ngx_pcalloc(r->pool, sizeof(ngx_regex_compile_t));
   return_value_if(!rgc, NGX_CONF_ERROR);
+#if (NGX_PCRE2)
+  rgc->options  = PCRE2_CASELESS | PCRE2_MULTILINE;
+#else
   rgc->options  = PCRE_CASELESS | PCRE_MULTILINE;
+#endif
   rgc->pattern  = ha;
   rgc->pool     = r->pool;
   rgc->err.len  = 0;

--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -270,7 +270,7 @@ ngx_http_process_basic_rule_buffer(ngx_str_t* str, ngx_http_rule_t* rl, ngx_int_
     tmp_idx = 0;
     len     = str->len;
     while
-#if defined nginx_version && (nginx_version >= 1021005)
+#if (NGX_PCRE2)
       (tmp_idx < len && (match = ngx_pcre2_exec(rl->br->rx->regex,                         
                                            str->data,
                                            str->len,
@@ -572,7 +572,7 @@ ngx_http_naxsi_pcre_wrapper(ngx_regex_compile_t* rx, unsigned char* str, unsigne
   int match;
   int captures[30];
 
-#if defined nginx_version && (nginx_version >= 1021005)
+#if (NGX_PCRE2)
   match = ngx_pcre2_exec(rx->regex, str, len, 0, captures, 1);
 #elif defined nginx_version && (nginx_version >= 1002002 && nginx_version != 1003000)
   match = pcre_exec(rx->regex->code, 0, (const char*)str, len, 0, 0, captures, 1);

--- a/naxsi_src/naxsi_utils.c
+++ b/naxsi_src/naxsi_utils.c
@@ -800,7 +800,11 @@ ngx_http_naxsi_create_hashtables_n(ngx_http_naxsi_loc_conf_t* dlc, ngx_conf_t* c
             ngx_pcalloc(cf->pool, sizeof(ngx_regex_compile_t));
           rgc = custloc_array(curr_r->br->custom_locations->elts)[name_idx].target_rx;
           if (rgc) {
+#if (NGX_PCRE2)
+            rgc->options  = PCRE2_CASELESS | PCRE2_MULTILINE;
+#else
             rgc->options  = PCRE_CASELESS | PCRE_MULTILINE;
+#endif
             rgc->pattern  = custloc_array(curr_r->br->custom_locations->elts)[name_idx].target;
             rgc->pool     = cf->pool;
             rgc->err.len  = 0;
@@ -816,7 +820,11 @@ ngx_http_naxsi_create_hashtables_n(ngx_http_naxsi_loc_conf_t* dlc, ngx_conf_t* c
             ngx_pcalloc(cf->pool, sizeof(ngx_regex_compile_t));
           rgc = custloc_array(curr_r->br->custom_locations->elts)[uri_idx].target_rx;
           if (rgc) {
+#if (NGX_PCRE2)
+            rgc->options  = PCRE2_CASELESS | PCRE2_MULTILINE;
+#else
             rgc->options  = PCRE_CASELESS | PCRE_MULTILINE;
+#endif
             rgc->pattern  = custloc_array(curr_r->br->custom_locations->elts)[uri_idx].target;
             rgc->pool     = cf->pool;
             rgc->err.len  = 0;


### PR DESCRIPTION
Essentially this is a revised #585 and builds upon it.

Unfortunately, the original pull request fails to compile *mainline* NGINX when:

* pcre2 is installed
* the original pcre (`pcre.h`) is not installed

Example:

```console
/home/danila/Projects/naxsi/naxsi_src/naxsi_config.c:326:44: error: ‘PCRE_CASELESS’ undeclared (first use in this function); did you mean ‘PCRE2_CASELESS’?
         custom_rule->target_rx->options  = PCRE_CASELESS | PCRE_MULTILINE;
                                            ^~~~~~~~~~~~~
                                            PCRE2_CASELESS
```

So essentially it only compiles fine if you have both `pcre` and `pcre2` libraries on your system, which is undesired.

First of all, we should no longer include `pcre.h` explicitly as the right header included by NGINX anyway.
We use conditionals to target the right pcre constants so the module compiles fine with only pcre vs pcre2 includes installed.
Next, I believe just checking conditional `#if (NGX_PCRE2)` is better, it should be available appropriately.