### PR TITLE
parse HTTP PATCH requests and associated tests

### DIFF
--- a/naxsi_src/naxsi_runtime.c
+++ b/naxsi_src/naxsi_runtime.c
@@ -2828,8 +2828,8 @@ ngx_http_naxsi_data_parse(ngx_http_request_ctx_t* ctx, ngx_http_request_t* r)
   /* check args */
   ngx_http_naxsi_args_parse(main_cf, cf, ctx, r);
   /* check method */
-  if ((r->method == NGX_HTTP_POST || r->method == NGX_HTTP_PUT) &&
-      /* presence of body rules (POST/PUT rules) */
+  if ((r->method == NGX_HTTP_PATCH || r->method == NGX_HTTP_POST || r->method == NGX_HTTP_PUT) &&
+      /* presence of body rules (PATCH/POST/PUT rules) */
       (cf->body_rules || main_cf->body_rules) &&
       /* and the presence of data to parse */
       r->request_body && ((!ctx->block || ctx->learning) && !ctx->drop))

--- a/t/00naxsi_base.t
+++ b/t/00naxsi_base.t
@@ -1293,6 +1293,89 @@ txtName=matchme&btnSign=Sign+Guestbook\r
 "
 --- error_code: 412
 
+=== TEST 38: SIMPLE PATCH (www-form style)
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- http_config
+include /tmp/naxsi_ut/naxsi_core.rules;
+--- config
+location / {
+	 #LearningMode;
+	 SecRulesEnabled;
+	 DeniedUrl "/RequestDenied";
+	 CheckRule "$SQL >= 8" BLOCK;
+	 CheckRule "$RFI >= 8" BLOCK;
+	 CheckRule "$TRAVERSAL >= 4" BLOCK;
+	 CheckRule "$XSS >= 8" BLOCK;
+	 root $TEST_NGINX_SERVROOT/html/;
+	 index index.html index.htm;
+	 error_page 405 = $uri;
+}
+location /RequestDenied {
+	 return 412;
+}
+--- more_headers
+Content-Type: application/x-www-form-urlencoded
+--- request eval
+use URI::Escape;
+"PATCH /
+foo1=bar1&foo2=bar2"
+--- error_code: 200
 
+=== TEST 39 : SQLi PATCH (www-form style)
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- http_config
+include /tmp/naxsi_ut/naxsi_core.rules;
+--- config
+location / {
+	 #LearningMode;
+	 SecRulesEnabled;
+	 DeniedUrl "/RequestDenied";
+	 CheckRule "$SQL >= 8" BLOCK;
+	 CheckRule "$RFI >= 8" BLOCK;
+	 CheckRule "$TRAVERSAL >= 4" BLOCK;
+	 CheckRule "$XSS >= 8" BLOCK;
+	 root $TEST_NGINX_SERVROOT/html/;
+	 index index.html index.htm;
+	 error_page 405 = $uri;
+}
+location /RequestDenied {
+	 return 412;
+}
+--- more_headers
+Content-Type: application/x-www-form-urlencoded
+--- request eval
+use URI::Escape;
+"PATCH /
+foo1=' OR '1'='1"
+--- error_code: 412
 
-
+=== TEST 40 : XSS PATCH (www-form style)
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- http_config
+include /tmp/naxsi_ut/naxsi_core.rules;
+--- config
+location / {
+	 #LearningMode;
+	 SecRulesEnabled;
+	 DeniedUrl "/RequestDenied";
+	 CheckRule "$SQL >= 8" BLOCK;
+	 CheckRule "$RFI >= 8" BLOCK;
+	 CheckRule "$TRAVERSAL >= 4" BLOCK;
+	 CheckRule "$XSS >= 8" BLOCK;
+	 root $TEST_NGINX_SERVROOT/html/;
+	 index index.html index.htm;
+	 error_page 405 = $uri;
+}
+location /RequestDenied {
+	 return 412;
+}
+--- more_headers
+Content-Type: application/x-www-form-urlencoded
+--- request eval
+use URI::Escape;
+"PATCH /
+foo1='><script>alert(1)</script>"
+--- error_code: 412

--- a/t/14json.t
+++ b/t/14json.t
@@ -867,3 +867,103 @@ use URI::Escape;
     \"MyKey\": \"MyValue \0 <script>alert('1')</script>\"
 }"
 --- error_code: 412
+
+=== JSON17 : Valid JSON With HTTP Patch Method
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- http_config
+include /tmp/naxsi_ut/naxsi_core.rules;
+--- config
+location / {
+         SecRulesEnabled;
+         DeniedUrl "/RequestDenied";
+         CheckRule "$SQL >= 8" BLOCK;
+         CheckRule "$RFI >= 8" BLOCK;
+         CheckRule "$TRAVERSAL >= 4" BLOCK;
+         CheckRule "$XSS >= 8" BLOCK;
+         root $TEST_NGINX_SERVROOT/html/;
+         index index.html index.htm;
+         error_page 405 = $uri;
+}
+location /RequestDenied {
+         return 412;
+}
+--- more_headers
+Content-Type: application/json
+--- request eval
+use URI::Escape;
+"PATCH /
+{
+    \"glossary\": {
+        \"title\": \"example glossary\",
+\"GlossDiv\": {
+            \"title\": \"S\",
+\"GlossList\": {
+                \"GlossEntry\": {
+                    \"ID\": \"SGML\",
+\"SortAs\": \"SGML\",
+\"GlossTerm\": \"Standard Generalized Markup Language\",
+\"Acronym\": \"SGML\",
+\"Abbrev\": \"ISO 8879:1986\",
+\"GlossDef\": {
+                        \"para\": \"A meta-markup language used to create markup languages such as DocBook.\",
+\"GlossSeeAlso\": [\"GML\", \"XML\"]
+                    },
+\"GlossSee\": \"markup\"
+                }
+            }
+        }
+    }
+}
+"
+--- error_code: 200
+
+=== JSON1 : invalid JSON With HTTP Patch Method (double closing ']')
+--- main_config
+load_module /tmp/naxsi_ut/modules/ngx_http_naxsi_module.so;
+--- http_config
+include /tmp/naxsi_ut/naxsi_core.rules;
+--- config
+location / {
+         SecRulesEnabled;
+         DeniedUrl "/RequestDenied";
+         CheckRule "$SQL >= 8" BLOCK;
+         CheckRule "$RFI >= 8" BLOCK;
+         CheckRule "$TRAVERSAL >= 4" BLOCK;
+         CheckRule "$XSS >= 8" BLOCK;
+         root $TEST_NGINX_SERVROOT/html/;
+         index index.html index.htm;
+         error_page 405 = $uri;
+}
+location /RequestDenied {
+         return 412;
+}
+--- more_headers
+Content-Type: application/json
+--- request eval
+use URI::Escape;
+"PATCH /
+{
+    \"glossary\": {
+        \"title\": \"example glossary\",
+\"GlossDiv\": {
+            \"title\": \"S\",
+\"GlossList\": {
+                \"GlossEntry\": {
+                    \"ID\": \"SGML\",
+\"SortAs\": \"SGML\",
+\"GlossTerm\": \"Standard Generalized Markup Language\",
+\"Acronym\": \"SGML\",
+\"Abbrev\": \"ISO 8879:1986\",
+\"GlossDef\": {
+                        \"para\": \"A meta-markup language used to create markup languages such as DocBook.\",
+\"GlossSeeAlso\": [\"GML\", \"XML\"]]
+                    },
+\"GlossSee\": \"markup\"
+                }
+            }
+        }
+    }
+}
+"
+--- error_code: 412


### PR DESCRIPTION
PR to fix https://github.com/nbs-system/naxsi/issues/539

I appreciate it's been a while since I opened the above issue, so apologies in the delay of this fix.

This PR adds back in the functionality to parse HTTP PATCH requests, which appears to have been a regression in versions > 1.0

I have also added some additional test with this.

All tests pass locally, but C is not something I deal with regularly, so let me know if more tests are needed etc, or if this will suffice

I have also tested this locally and can confirm that nginx running with naxsi compiled from this PR successfully blocks PATCH requests, such as the one from my original issue https://github.com/nbs-system/naxsi/issues/539
``` curl -i -XPATCH "http://127.0.0.1/" --data-raw '{"a":"select * from table1;"}'```