### PR TITLE
Fix regex options for recent Nginx

### DIFF
--- a/naxsi_src/naxsi_config.c
+++ b/naxsi_src/naxsi_config.c
@@ -322,7 +322,9 @@ naxsi_zone(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
 
         custom_rule->target_rx = ngx_pcalloc(r->pool, sizeof(ngx_regex_compile_t));
         return_value_if(!custom_rule->target_rx, NGX_CONF_ERROR);
-#if (NGX_PCRE2)
+#ifdef NGX_REGEX_CASELESS
+        custom_rule->target_rx->options  = NGX_REGEX_CASELESS | NGX_REGEX_MULTILINE;
+#elif (NGX_PCRE2)
         custom_rule->target_rx->options  = PCRE2_CASELESS | PCRE2_MULTILINE;
 #else
         custom_rule->target_rx->options  = PCRE_CASELESS | PCRE_MULTILINE;
@@ -445,7 +447,9 @@ naxsi_rx(ngx_conf_t* r, ngx_str_t* tmp, ngx_http_rule_t* rule)
   ha.len  = tmp->len - strlen(RX_T);
   rgc     = ngx_pcalloc(r->pool, sizeof(ngx_regex_compile_t));
   return_value_if(!rgc, NGX_CONF_ERROR);
-#if (NGX_PCRE2)
+#ifdef NGX_REGEX_CASELESS
+  rgc->options  = NGX_REGEX_CASELESS | NGX_REGEX_MULTILINE;
+#elif (NGX_PCRE2)
   rgc->options  = PCRE2_CASELESS | PCRE2_MULTILINE;
 #else
   rgc->options  = PCRE_CASELESS | PCRE_MULTILINE;


### PR DESCRIPTION
The current Nginx expects the regex options to be NGX_REGEX_* rather than the bits from PCRE. Without this change, regexes with these options set won't compile. In particular, "rx:" rules don't work.